### PR TITLE
Add /tip ... --anonymous to hide donation source from the recipient

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -15,7 +15,7 @@ Usage:
   c decode <invoice>
   c (receive | invoice | fund) <satoshis> [<description>...] [--preimage=<preimage>]
   c (pay [now] | paynow | withdraw) [<invoice>] [<satoshis>]
-  c (send | tip) <satoshis> [<receiver>...]
+  c (send | tip) <satoshis> [<receiver>...] [--anonymous]
   c balance
   c transactions [--page=<page>]
   c giveaway <satoshis>

--- a/handle_message.go
+++ b/handle_message.go
@@ -219,6 +219,8 @@ parsed:
 		}
 
 	gotusername:
+		anonymous, _ := opts.Bool("--anonymous")
+
 		receiver, todisplayname, err = parseUsername(message, usernameval)
 		if err != nil {
 			break
@@ -275,7 +277,11 @@ parsed:
 		}
 
 		if receiver.ChatId != 0 {
-			receiver.notify(fmt.Sprintf("%s has sent you %d sat.", u.AtName(), sats))
+			if anonymous {
+				receiver.notify(fmt.Sprintf("Someone has sent you %d sat.", sats))
+			} else {
+				receiver.notify(fmt.Sprintf("%s has sent you %d sat.", u.AtName(), sats))
+			}
 		}
 
 		if message.Chat.Type == "private" {


### PR DESCRIPTION
It's not always desirable that the recipient knows who's sent a tip. 
Allow the donor to decide, by adding --anonymous flag to the /tip (/send) command.